### PR TITLE
"entrySet()" should be iterated when both the key and value are needed

### DIFF
--- a/app/src/main/java/org/secfirst/umbrella/SettingsActivity.java
+++ b/app/src/main/java/org/secfirst/umbrella/SettingsActivity.java
@@ -42,6 +42,7 @@ import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 
 public class SettingsActivity extends BaseActivity {
@@ -226,12 +227,12 @@ public class SettingsActivity extends BaseActivity {
         int selectedIndex = 0;
         int i = 0;
         final HashMap<String, Integer> refreshValues = UmbrellaUtil.getRefreshValues(SettingsActivity.this);
-        for (Object key : refreshValues.keySet()) {
-            if (refreshValues.get(key).equals(currentRefresh)) {
+        for (Map.Entry<String, Integer> entry : refreshValues.entrySet()) {
+            if (entry.getValue().equals(currentRefresh)) {
                 selectedIndex = i;
 
             }
-            arrayAdapter.add((String) key);
+            arrayAdapter.add((String) entry.getKey());
             i++;
         }
         builderSingle.setNegativeButton(R.string.cancel,
@@ -248,9 +249,9 @@ public class SettingsActivity extends BaseActivity {
                     @Override
                     public void onClick(DialogInterface dialog, int which) {
                         String chosen = arrayAdapter.getItem(which);
-                        for (Object key : refreshValues.keySet()) {
-                            Integer value = refreshValues.get(key);
-                            if (key.equals(chosen)) {
+                        for (Map.Entry<String, Integer> entry : refreshValues.entrySet()) {
+                            Integer value = entry.getValue();
+                            if (entry.getKey().equals(chosen)) {
                                 if (mBounded) mService.setRefresh(value);
                                 global.setRefreshValue(value);
                                 dialog.dismiss();

--- a/app/src/main/java/org/secfirst/umbrella/fragments/TabbedFeedFragment.java
+++ b/app/src/main/java/org/secfirst/umbrella/fragments/TabbedFeedFragment.java
@@ -54,6 +54,7 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 public class TabbedFeedFragment extends Fragment implements SwipeRefreshLayout.OnRefreshListener {
     SwipeRefreshLayout mSwipeRefreshLayout;
@@ -370,12 +371,12 @@ public class TabbedFeedFragment extends Fragment implements SwipeRefreshLayout.O
         int selectedIndex = 0;
         int i = 0;
         final HashMap<String, Integer> refreshValues = UmbrellaUtil.getRefreshValues(global.getApplicationContext());
-        for (Object key : refreshValues.keySet()) {
-            if (refreshValues.get(key).equals(currentRefresh)) {
+        for (Map.Entry<String, Integer> entry : refreshValues.entrySet()) {
+            if (entry.getValue().equals(currentRefresh)) {
                 selectedIndex = i;
 
             }
-            arrayAdapter.add((String) key);
+            arrayAdapter.add((String) entry.getKey());
             i++;
         }
         builderSingle.setNegativeButton(global.getString(R.string.cancel),
@@ -392,9 +393,9 @@ public class TabbedFeedFragment extends Fragment implements SwipeRefreshLayout.O
                     @Override
                     public void onClick(DialogInterface dialog, int which) {
                         String chosen = arrayAdapter.getItem(which);
-                        for (Object key : refreshValues.keySet()) {
-                            Integer value = refreshValues.get(key);
-                            if (key.equals(chosen)) {
+                        for (Map.Entry<String, Integer> entry : refreshValues.entrySet()) {
+                            Integer value = entry.getValue();
+                            if (entry.getKey().equals(chosen)) {
                                 BaseActivity baseAct = ((BaseActivity) getActivity());
                                 if (baseAct.mBounded) baseAct.mService.setRefresh(value);
                                 global.setRefreshValue(value);

--- a/app/src/main/java/org/secfirst/umbrella/util/Global.java
+++ b/app/src/main/java/org/secfirst/umbrella/util/Global.java
@@ -52,6 +52,7 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 public class Global extends Application {
 
@@ -404,9 +405,9 @@ public class Global extends Application {
         String refreshValueLabel = "";
         int refreshValue = getRefreshValue();
         HashMap<String, Integer> refreshValues = UmbrellaUtil.getRefreshValues(getApplicationContext());
-        for (Object key : refreshValues.keySet()) {
-            if (refreshValues.get(key).equals(refreshValue)) {
-                refreshValueLabel = (String) key;
+        for (Map.Entry<String, Integer> entry : refreshValues.entrySet()) {
+            if (entry.getValue().equals(refreshValue)) {
+                refreshValueLabel = (String) entry.getKey();
             }
         }
         return refreshValueLabel;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S2864 - “"entrySet()" should be iterated when both the key and value are needed ”. 
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2864
Please let me know if you have any questions.
Ayman Abdelghany.
