### PR TITLE
Useless parentheses around expressions should be removed

### DIFF
--- a/app/src/main/java/org/secfirst/umbrella/fragments/TabbedFeedFragment.java
+++ b/app/src/main/java/org/secfirst/umbrella/fragments/TabbedFeedFragment.java
@@ -395,7 +395,7 @@ public class TabbedFeedFragment extends Fragment implements SwipeRefreshLayout.O
                         for (Object key : refreshValues.keySet()) {
                             Integer value = refreshValues.get(key);
                             if (key.equals(chosen)) {
-                                BaseActivity baseAct = ((BaseActivity) getActivity());
+                                BaseActivity baseAct = (BaseActivity) getActivity();
                                 if (baseAct.mBounded) baseAct.mService.setRefresh(value);
                                 global.setRefreshValue(value);
                                 refreshIntervalValue.setText(global.getRefreshLabel());

--- a/app/src/main/java/org/secfirst/umbrella/models/CheckItem.java
+++ b/app/src/main/java/org/secfirst/umbrella/models/CheckItem.java
@@ -41,7 +41,7 @@ public class CheckItem implements Serializable {
     public CheckItem(String title, String text, boolean value, long parent, int category, int difficulty) {
         this.title = title;
         this.text = text;
-        this.value = (value) ? 1 : 0;
+        this.value = value ? 1 : 0;
         this.parent = parent;
         this.category = category;
         this.difficulty = difficulty;
@@ -50,7 +50,7 @@ public class CheckItem implements Serializable {
     public CheckItem(String title, String text, boolean value, long parent, int category, int difficulty, boolean noCheck) {
         this.title = title;
         this.text = text;
-        this.value = (value) ? 1 : 0;
+        this.value = value ? 1 : 0;
         this.parent = parent;
         this.category = category;
         this.difficulty = difficulty;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:UselessParenthesesCheck - “ Useless parentheses around expressions should be removed to prevent any misunderstanding ”. 
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:UselessParenthesesCheck
Please let me know if you have any questions.
Ayman Abdelghany.
