### PR TITLE
Local Variables should not be declared and then immediately returned or thrown

### DIFF
--- a/app/libs/ormlite-android-sqlcipher/src/main/java/com/j256/ormlite/sqlcipher/android/apptools/OpenHelperManager.java
+++ b/app/libs/ormlite-android-sqlcipher/src/main/java/com/j256/ormlite/sqlcipher/android/apptools/OpenHelperManager.java
@@ -198,8 +198,7 @@ public class OpenHelperManager {
 		instanceCount++;
 		logger.trace("returning helper {}, instance count = {} ", helper, instanceCount);
 		@SuppressWarnings("unchecked")
-		T castHelper = (T) helper;
-		return castHelper;
+		return (T) helper;
 	}
 
 	/**
@@ -233,10 +232,7 @@ public class OpenHelperManager {
 		if (resourceId != 0) {
 			String className = resources.getString(resourceId);
 			try {
-				@SuppressWarnings("unchecked")
-				Class<? extends OrmLiteSqliteOpenHelper> castClass =
-						(Class<? extends OrmLiteSqliteOpenHelper>) Class.forName(className);
-				return castClass;
+				return (Class<? extends OrmLiteSqliteOpenHelper>) Class.forName(className);
 			} catch (Exception e) {
 				throw new IllegalStateException("Could not create helper instance for class " + className, e);
 			}
@@ -262,10 +258,7 @@ public class OpenHelperManager {
 				}
 				Class<?> clazz = (Class<?>) type;
 				if (OrmLiteSqliteOpenHelper.class.isAssignableFrom(clazz)) {
-					@SuppressWarnings("unchecked")
-					Class<? extends OrmLiteSqliteOpenHelper> castOpenHelperClass =
-							(Class<? extends OrmLiteSqliteOpenHelper>) clazz;
-					return castOpenHelperClass;
+					return (Class<? extends OrmLiteSqliteOpenHelper>) clazz;
 				}
 			}
 		}

--- a/app/libs/ormlite-android-sqlcipher/src/main/java/com/j256/ormlite/sqlcipher/android/apptools/OrmLiteBaseActivityGroup.java
+++ b/app/libs/ormlite-android-sqlcipher/src/main/java/com/j256/ormlite/sqlcipher/android/apptools/OrmLiteBaseActivityGroup.java
@@ -76,9 +76,7 @@ public abstract class OrmLiteBaseActivityGroup<H extends OrmLiteSqliteOpenHelper
 	 * </p>
 	 */
 	protected H getHelperInternal(Context context) {
-		@SuppressWarnings({ "unchecked", "deprecation" })
-		H newHelper = (H) OpenHelperManager.getHelper(context);
-		return newHelper;
+		return (H) OpenHelperManager.getHelper(context);
 	}
 
 	/**

--- a/app/libs/ormlite-android-sqlcipher/src/main/java/com/j256/ormlite/sqlcipher/android/apptools/OrmLiteBaseListActivity.java
+++ b/app/libs/ormlite-android-sqlcipher/src/main/java/com/j256/ormlite/sqlcipher/android/apptools/OrmLiteBaseListActivity.java
@@ -70,9 +70,7 @@ public abstract class OrmLiteBaseListActivity<H extends OrmLiteSqliteOpenHelper>
 	 * </p>
 	 */
 	protected H getHelperInternal(Context context) {
-		@SuppressWarnings({ "unchecked", "deprecation" })
-		H newHelper = (H) OpenHelperManager.getHelper(context);
-		return newHelper;
+		return (H) OpenHelperManager.getHelper(context);
 	}
 
 	/**

--- a/app/libs/ormlite-android-sqlcipher/src/main/java/com/j256/ormlite/sqlcipher/android/apptools/OrmLiteBaseService.java
+++ b/app/libs/ormlite-android-sqlcipher/src/main/java/com/j256/ormlite/sqlcipher/android/apptools/OrmLiteBaseService.java
@@ -69,9 +69,7 @@ public abstract class OrmLiteBaseService<H extends OrmLiteSqliteOpenHelper> exte
 	 * </p>
 	 */
 	protected H getHelperInternal(Context context) {
-		@SuppressWarnings({ "unchecked", "deprecation" })
-		H newHelper = (H) OpenHelperManager.getHelper(context);
-		return newHelper;
+		return (H) OpenHelperManager.getHelper(context);
 	}
 
 	/**

--- a/app/libs/ormlite-android-sqlcipher/src/main/java/com/j256/ormlite/sqlcipher/android/apptools/OrmLiteBaseTabActivity.java
+++ b/app/libs/ormlite-android-sqlcipher/src/main/java/com/j256/ormlite/sqlcipher/android/apptools/OrmLiteBaseTabActivity.java
@@ -72,9 +72,7 @@ public abstract class OrmLiteBaseTabActivity<H extends OrmLiteSqliteOpenHelper> 
 	 * @see OpenHelperManager#getHelper(Context)
 	 */
 	protected H getHelperInternal(Context context) {
-		@SuppressWarnings({ "unchecked", "deprecation" })
-		H newHelper = (H) OpenHelperManager.getHelper(context);
-		return newHelper;
+		return (H) OpenHelperManager.getHelper(context);
 	}
 
 	/**

--- a/app/libs/ormlite-android-sqlcipher/src/main/java/com/j256/ormlite/sqlcipher/android/apptools/OrmLiteSqliteOpenHelper.java
+++ b/app/libs/ormlite-android-sqlcipher/src/main/java/com/j256/ormlite/sqlcipher/android/apptools/OrmLiteSqliteOpenHelper.java
@@ -271,10 +271,7 @@ public abstract class OrmLiteSqliteOpenHelper extends SQLiteOpenHelper {
 	 */
 	public <D extends Dao<T, ?>, T> D getDao(Class<T> clazz) throws SQLException {
 		// special reflection fu is now handled internally by create dao calling the database type
-		Dao<T, ?> dao = DaoManager.createDao(getConnectionSource(), clazz);
-		@SuppressWarnings("unchecked")
-		D castDao = (D) dao;
-		return castDao;
+		return (D) DaoManager.createDao(getConnectionSource(), clazz);
 	}
 
 	/**
@@ -287,10 +284,7 @@ public abstract class OrmLiteSqliteOpenHelper extends SQLiteOpenHelper {
 	 */
 	public <D extends RuntimeExceptionDao<T, ?>, T> D getRuntimeExceptionDao(Class<T> clazz) {
 		try {
-			Dao<T, ?> dao = getDao(clazz);
-			@SuppressWarnings({ "unchecked", "rawtypes" })
-			D castDao = (D) new RuntimeExceptionDao(dao);
-			return castDao;
+			return (D) new RuntimeExceptionDao(dao);
 		} catch (SQLException e) {
 			throw new RuntimeException("Could not create RuntimeExcepitionDao for class " + clazz, e);
 		}


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1488 - “Local Variables should not be declared and then immediately returned or thrown”. 
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1488
Please let me know if you have any questions.
Ayman Abdelghany.
