### PR TITLE
Utility classes should not have public constructors

### DIFF
--- a/app/src/main/java/org/secfirst/umbrella/util/UmbrellaRestClient.java
+++ b/app/src/main/java/org/secfirst/umbrella/util/UmbrellaRestClient.java
@@ -24,6 +24,9 @@ public class UmbrellaRestClient {
 
     private static AsyncHttpClient client = new AsyncHttpClient();
 
+    private UmbrellaRestClient() {
+    }
+
     public static AsyncHttpClient getClientForApiUpdates(Context context) {
         AsyncHttpClient client = new AsyncHttpClient();
         String[] pins                 = new String[] {"19ed92909228c6ffc29da6b79d05bc83bab15a78", "852627ad032bf9ab22e416cbbf9e32bc1187366f"};

--- a/app/src/main/java/org/secfirst/umbrella/util/UmbrellaUtil.java
+++ b/app/src/main/java/org/secfirst/umbrella/util/UmbrellaUtil.java
@@ -42,6 +42,9 @@ import java.util.regex.Pattern;
 
 public class UmbrellaUtil {
 
+    private UmbrellaUtil() {
+    }
+
     public static void hideSoftKeyboard(Activity activity) {
         if (activity!=null) {
             InputMethodManager inputMethodManager = (InputMethodManager)  activity.getSystemService(Activity.INPUT_METHOD_SERVICE);

--- a/app/src/main/java/org/secfirst/umbrella/util/UpgradeHelper.java
+++ b/app/src/main/java/org/secfirst/umbrella/util/UpgradeHelper.java
@@ -25,6 +25,9 @@ public class UpgradeHelper {
         VERSION = new LinkedHashSet<>();
     }
 
+    private UpgradeHelper() {
+    }
+
     /**
      * Add the given version to the list of available updates
      */


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1118 - “Utility classes should not have public constructors ”. 
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1118
Please let me know if you have any questions.
Ayman Abdelghany.
