### PR TITLE
add leak canary

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -88,6 +88,7 @@ dependencies {
     implementation "io.github.inflationx:viewpump:$viewpump"
     implementation "org.apache.commons:commons-text:$commonsText"
     implementation "org.apache.commons:commons-lang3:$commonsLang"
+    debugImplementation 'com.squareup.leakcanary:leakcanary-android:2.3'
 
 
     //Framework for replacing fragments


### PR DESCRIPTION
What this PR does:

adds leak canary to check memory leaks as a suggestion

square.github.io/leakcanary

<img width="1280" alt="Screenshot 2020-06-18 at 16 10 48" src="https://user-images.githubusercontent.com/29093946/85038514-93176100-b17e-11ea-9bd5-9d3ddcba5959.png">

when compiling, you can check the leaks going to the leaks extension here

<img width="383" alt="Screenshot 2020-05-12 at 22 20 05" src="https://user-images.githubusercontent.com/29093946/85038566-a296aa00-b17e-11ea-959d-bf5f461d9bb2.png">

<img width="1654" alt="Screenshot 2020-06-18 at 16 17 42" src="https://user-images.githubusercontent.com/29093946/85038806-edb0bd00-b17e-11ea-9217-5ac7ca82b6f4.png">



