### PR TITLE
Bugfix: Lessons Missing Section Seven

### DIFF
--- a/app/src/main/java/org/secfirst/umbrella/feature/segment/presenter/SegmentBasePresenter.kt
+++ b/app/src/main/java/org/secfirst/umbrella/feature/segment/presenter/SegmentBasePresenter.kt
@@ -20,7 +20,7 @@ interface SegmentBasePresenter<V : SegmentView, I : SegmentBaseInteractor> : Bas
 
     fun submitMarkdowns(markdownIds: ArrayList<String>)
 
-    fun submitMarkdownsAndChecklist(markdownIds: ArrayList<String>, checklistId: String, removeLastItem : Boolean)
+    fun submitMarkdownsAndChecklist(markdownIds: ArrayList<String>, checklistId: String)
 
     fun submitDifficulties(difficultyIds: ArrayList<String>)
 

--- a/app/src/main/java/org/secfirst/umbrella/feature/segment/presenter/SegmentPresenterImp.kt
+++ b/app/src/main/java/org/secfirst/umbrella/feature/segment/presenter/SegmentPresenterImp.kt
@@ -92,7 +92,6 @@ class SegmentPresenterImp<V : SegmentView, I : SegmentBaseInteractor> @Inject co
     override fun submitMarkdownsAndChecklist(markdownIds: ArrayList<String>, checklistId: String) {
         launchSilent(uiContext) {
             val markdowns = mutableListOf<Markdown>()
-            var index = 0
             interactor?.let {
                 markdownIds.forEach { markdownId ->
                     it.fetchMarkdown(markdownId)?.let { markdown -> markdowns.add(markdown) }

--- a/app/src/main/java/org/secfirst/umbrella/feature/segment/presenter/SegmentPresenterImp.kt
+++ b/app/src/main/java/org/secfirst/umbrella/feature/segment/presenter/SegmentPresenterImp.kt
@@ -89,22 +89,25 @@ class SegmentPresenterImp<V : SegmentView, I : SegmentBaseInteractor> @Inject co
         }
     }
 
-    override fun submitMarkdownsAndChecklist(markdownIds: ArrayList<String>, checklistId: String, removeLastItem: Boolean) {
+    override fun submitMarkdownsAndChecklist(markdownIds: ArrayList<String>, checklistId: String) {
         launchSilent(uiContext) {
             val markdowns = mutableListOf<Markdown>()
+            var index = 0
             interactor?.let {
                 markdownIds.forEach { markdownId ->
                     it.fetchMarkdown(markdownId)?.let { markdown -> markdowns.add(markdown) }
                 }
-                if (removeLastItem) {
-                    val removeLastMark = Markdown()
-                    removeLastMark.isRemove = true
-                    removeLastMark.index = "500"
-                    markdowns.add(removeLastMark)
-                }
-
                 val checklist = it.fetchChecklist(checklistId)
                 markdowns.sortBy { it.title.capitalize() }
+
+                // In case of uneven number of markdowns, add an empty markdown so that the last markdown doesn't take the entire width
+                if (markdowns.size % 2 != 0) {
+                    val emptyBufferMark = Markdown()
+                    emptyBufferMark.isRemove = true
+                    emptyBufferMark.index = "500"
+                    markdowns.add(markdowns.size, emptyBufferMark)
+                }
+
                 getView()?.showSegments(markdowns, checklist)
             }
         }

--- a/app/src/main/java/org/secfirst/umbrella/feature/segment/view/controller/SegmentController.kt
+++ b/app/src/main/java/org/secfirst/umbrella/feature/segment/view/controller/SegmentController.kt
@@ -92,9 +92,8 @@ class SegmentController(bundle: Bundle) : BaseController(bundle), SegmentView {
                     .setView(shareView)
                     .create()
             presenter.onAttach(this)
-            var removeLast = false
-            markdownIds?.let { if (it.size % 2 != 0) removeLast = true }
-            presenter.submitMarkdownsAndChecklist(markdownIds, checklistId, removeLast)
+            //markdownIds?.let { if (it.size % 2 != 0) removeLast = true }
+            presenter.submitMarkdownsAndChecklist(markdownIds, checklistId)
             if (isFromDashboard) {
                 onSegmentClicked(markdownIds!!.size)
             }

--- a/app/src/main/java/org/secfirst/umbrella/feature/segment/view/controller/SegmentController.kt
+++ b/app/src/main/java/org/secfirst/umbrella/feature/segment/view/controller/SegmentController.kt
@@ -92,7 +92,6 @@ class SegmentController(bundle: Bundle) : BaseController(bundle), SegmentView {
                     .setView(shareView)
                     .create()
             presenter.onAttach(this)
-            //markdownIds?.let { if (it.size % 2 != 0) removeLast = true }
             presenter.submitMarkdownsAndChecklist(markdownIds, checklistId)
             if (isFromDashboard) {
                 onSegmentClicked(markdownIds!!.size)


### PR DESCRIPTION
Fixes #246 

After a brief investigation, it was found out that there is logic that is unnecessarily adding an empty section which causes this bug.
This feature introduces a solution that adds an empty section only after sorting all the sections and if the number of sections is uneven.

Tested in both even and uneven lessons. Also added a comment for readability and future developers.

![qemu-system-x86_64_p6Me9Ion4r](https://user-images.githubusercontent.com/23402988/141183240-69d384ea-36c0-4e2a-90b2-7e2a00b011f7.png)


![qemu-system-x86_64_0kIwUaB8Ee](https://user-images.githubusercontent.com/23402988/141183238-be525192-fff2-4c43-801f-2d172e03e2dd.png)


